### PR TITLE
Make the default db user for Administrator

### DIFF
--- a/manifests/sql.pp
+++ b/manifests/sql.pp
@@ -18,7 +18,7 @@ class tse_sqlserver::sql (
     'virtualbox':  {
       $admin_user  = 'vagrant'
     }
-    'openstack':  {
+    default:  {
       $admin_user  = 'Administrator'
     }
   }


### PR DESCRIPTION
Previously we had one user name for vagrant and
one for openstack. This commit makes
'Administrator' the default for all machines
whose virtual fact is not 'vagrant'. Thus
vmware and openstack and others will all use
'Administrator' as the default.